### PR TITLE
Add parameterized waitForBootstrap in BootstrapConsumerExecutor

### DIFF
--- a/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
+++ b/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
@@ -57,21 +57,24 @@ public class BootstrapConsumerExecutor<K, V, R> {
         }
     }
 
-    public void waitForBootstrap() throws InterruptedException {
+    public boolean waitForBootstrap() throws InterruptedException {
         for (BootstrapConsumerThread<K, V, R> thread : threads) {
-            thread.waitForBootstrap();
-        }
-    }
-
-    public boolean waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        boolean result = true;
-        for (BootstrapConsumerThread<K, V, R> thread : threads) {
-            if (!thread.waitForBootstrap(timeout, timeUnit)) {
-                result = false;
+            if (!thread.waitForBootstrap()) {
+                return false;
             }
         }
 
-        return result;
+        return true;
+    }
+
+    public boolean waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        for (BootstrapConsumerThread<K, V, R> thread : threads) {
+            if (!thread.waitForBootstrap(timeout, timeUnit)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public void shutdown() throws InterruptedException {

--- a/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
+++ b/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
@@ -17,6 +17,7 @@ package com.epam.eco.commons.kafka.consumer.bootstrap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -59,6 +60,12 @@ public class BootstrapConsumerExecutor<K, V, R> {
     public void waitForBootstrap() throws InterruptedException {
         for (BootstrapConsumerThread<K, V, R> thread : threads) {
             thread.waitForBootstrap();
+        }
+    }
+
+    public void waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        for (BootstrapConsumerThread<K, V, R> thread : threads) {
+            thread.waitForBootstrap(timeout, timeUnit);
         }
     }
 

--- a/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
+++ b/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerExecutor.java
@@ -63,10 +63,15 @@ public class BootstrapConsumerExecutor<K, V, R> {
         }
     }
 
-    public void waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    public boolean waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        boolean result = true;
         for (BootstrapConsumerThread<K, V, R> thread : threads) {
-            thread.waitForBootstrap(timeout, timeUnit);
+            if (!thread.waitForBootstrap(timeout, timeUnit)) {
+                result = false;
+            }
         }
+
+        return result;
     }
 
     public void shutdown() throws InterruptedException {

--- a/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerThread.java
+++ b/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerThread.java
@@ -75,8 +75,8 @@ class BootstrapConsumerThread<K, V, R> extends Thread {
                 (long)(consumer.getBootstrapTimeoutInMs() * 1.5), TimeUnit.MILLISECONDS);
     }
 
-    public void waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        bootstrapLatch.await(timeout, timeUnit);
+    public boolean waitForBootstrap(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return bootstrapLatch.await(timeout, timeUnit);
     }
 
 }

--- a/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerThread.java
+++ b/src/main/java/com/epam/eco/commons/kafka/consumer/bootstrap/BootstrapConsumerThread.java
@@ -70,8 +70,8 @@ class BootstrapConsumerThread<K, V, R> extends Thread {
         }
     }
 
-    public void waitForBootstrap() throws InterruptedException {
-        bootstrapLatch.await(
+    public boolean waitForBootstrap() throws InterruptedException {
+        return bootstrapLatch.await(
                 (long)(consumer.getBootstrapTimeoutInMs() * 1.5), TimeUnit.MILLISECONDS);
     }
 


### PR DESCRIPTION
We need to bootstrap data and want to be sure that bootstrap is completed successfully (not because of timeout). 
We can set up max long for bootstrapTimeoutInMs, but we will wait an infinite time if something goes wrong and `compareOffsetsGreaterOrEqual(consumedOffsets, latestOffsets)` = false constantly. 